### PR TITLE
reject pods when pg phase is empty

### DIFF
--- a/pkg/webhooks/admission/pods/admit_pod.go
+++ b/pkg/webhooks/admission/pods/admit_pod.go
@@ -146,7 +146,7 @@ func checkPGPhase(pod *v1.Pod, pgName string, isVCJob bool) error {
 		}
 		return nil
 	}
-	if pg.Status.Phase != vcv1beta1.PodGroupPending {
+	if pg.Status.Phase != "" && pg.Status.Phase != vcv1beta1.PodGroupPending {
 		return nil
 	}
 	return fmt.Errorf("failed to create pod <%s/%s> as the podgroup phase is Pending",


### PR DESCRIPTION
Until a pg is processed by scheduler, the phase is empty. This causes initial pod create requests to pass through admission checks even when they should fail