### PR TITLE
handle if there is no resource quota in the job namespace

### DIFF
--- a/pkg/scheduler/plugins/resourcequota/resourcequota.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota.go
@@ -42,7 +42,12 @@ func (rq *resourceQuotaPlugin) OnSessionOpen(ssn *framework.Session) {
 			return util.Permit
 		}
 
-		quotas := ssn.NamespaceInfo[api.NamespaceName(job.Namespace)].QuotaStatus
+		namespaceInfo := ssn.NamespaceInfo[api.NamespaceName(job.Namespace)]
+		if namespaceInfo == nil {
+			return util.Abstain
+		}
+
+		quotas := namespaceInfo.QuotaStatus
 		for _, resourceQuota := range quotas {
 			hardResources := quotav1.ResourceNames(resourceQuota.Hard)
 


### PR DESCRIPTION
currently, the scheduler goes into a crash loop. instead, abstain.